### PR TITLE
Updated map processing

### DIFF
--- a/workload/src/main/kotlin/org/taktik/couchdb/entity/Attachment.kt
+++ b/workload/src/main/kotlin/org/taktik/couchdb/entity/Attachment.kt
@@ -1,0 +1,12 @@
+package org.taktik.couchdb.entity
+
+class Attachment(
+    val id: String? = null,
+    val contentType: String? = null,
+    val contentLength: Long = 0,
+    val dataBase64: String? = null,
+    val isStub: Boolean = false,
+    val revpos: Int = 0,
+    val digest: String? = null,
+    val length: Long? = null
+)

--- a/workload/src/main/kotlin/org/taktik/icure/entities/Agenda.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/Agenda.kt
@@ -26,6 +26,7 @@ import org.taktik.icure.entities.utils.MergeUtil
 import org.taktik.icure.utils.DynamicInitializer
 import org.taktik.icure.utils.invoke
 
+//jlgybo
 data class Agenda(
        override val id: String,
        override val rev: String? = null,

--- a/workload/src/main/kotlin/org/taktik/icure/entities/ApplicationSettings.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/ApplicationSettings.kt
@@ -40,7 +40,6 @@ data class ApplicationSettings(
        override val revisionsInfo: List<RevisionInfo>? = emptyList(),
        override val conflicts: List<String>? = emptyList(),
        override val revHistory: Map<String, String>? = emptyMap()
-
 ) : StoredICureDocument {
     companion object : DynamicInitializer<ApplicationSettings>
 

--- a/workload/src/main/kotlin/org/taktik/icure/entities/Document.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/Document.kt
@@ -17,153 +17,152 @@
  */
 package org.taktik.icure.entities
 
+import org.taktik.couchdb.entity.Attachment
 import org.taktik.icure.entities.base.CodeStub
 import org.taktik.icure.entities.base.Encryptable
+import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.entities.base.StoredICureDocument
+import org.taktik.icure.entities.embed.DataAttachment
 import org.taktik.icure.entities.embed.Delegation
+import org.taktik.icure.entities.embed.DeletedAttachment
 import org.taktik.icure.entities.embed.DocumentLocation
 import org.taktik.icure.entities.embed.DocumentStatus
 import org.taktik.icure.entities.embed.DocumentType
 import org.taktik.icure.entities.embed.RevisionInfo
-import org.taktik.icure.security.CryptoUtils
-import org.taktik.icure.security.CryptoUtils.isValidAesKey
-import org.taktik.icure.security.CryptoUtils.keyFromHexString
 import org.taktik.icure.utils.DynamicInitializer
 import org.taktik.icure.utils.invoke
-import java.security.GeneralSecurityException
-import java.security.KeyException
-import java.util.*
 
-/**
- * This entity is a root level object. It represents a Document. It is serialized in JSON and saved in the underlying CouchDB database.
- * A Document conforms to a series of interfaces:
- * - StoredICureDocument
- * - Encryptable
- *
- * @property id The Id of the document. We encourage using either a v4 UUID or a HL7 Id.
- * @property rev The revision of the document in the database, used for conflict management / optimistic locking.
- * @property created The timestamp (unix epoch in ms) of creation of the document, will be filled automatically if missing. Not enforced by the application server.
- * @property modified The date (unix epoch in ms) of the latest modification of the document, will be filled automatically if missing. Not enforced by the application server.
- * @property author The id of the User that has created this document, will be filled automatically if missing. Not enforced by the application server.
- * @property responsible The id of the healthcare party that is responsible for this document, will be filled automatically if missing. Not enforced by the application server.
- * @property medicalLocationId The id of the medical location where the document was created.
- * @property tags Tags that qualify the document as being member of a certain class.
- * @property codes Codes that identify or qualify this particular document.
- * @property endOfLife Soft delete (unix epoch in ms) timestamp of the object.
- * @property deletionDate Hard delete (unix epoch in ms) timestamp of the object. Filled automatically when document is deleted.
- * @property size Size of the document file
- * @property hash Hashed version of the document
- * @property openingContactId Id of the contact during which the document was created
- * @property attachment Attachment for the document. This property is transient and is used to store the attachment temporarily inside the application server.
- * @property isAttachmentDirty If the attachment is dirty (data changes has not been synchronized back with the database) or not
- * @property documentLocation Location of the document
- * @property documentType The type of document, ex: admission, clinical path, document report,invoice, etc.
- * @property documentStatus The status of the development of the document. Ex: Draft, finalized, reviewed, signed, etc.
- * @property externalUri When the document is stored in an external repository, this is the uri of the document in that repository
- * @property mainUti The main Uniform Type Identifier of the document (https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-CHDHIJDE)
- * @property name Name of the document
- * @property version The document version
- * @property otherUtis Extra Uniform Type Identifiers
- * @property storedICureDocumentId The ICureDocument (Form, Contact, ...) that has been used to generate the document
- * @property externalUuid A unique external id (from another external source).
- * @property attachmentId Id of attachment to this document
- * @property idOpeningContact Id of the contact marking the beginning of a healthcare element for which the document was created
- * @property idClosingContact Id of the contact marking the end of a healthcare element for which the document was created.
- * @property delegations The delegations giving access to all connected healthcare information.
- * @property encryptionKeys The patient secret encryption key used to encrypt the secured properties (like note for example), encrypted for separate Crypto Actors.
- * @property encryptedSelf The encrypted fields of this document.
- *
- */
 
 data class Document(
-       override val id: String,
-       override val rev: String? = null,
-        override val created: Long? = null,
-        override val modified: Long? = null,
-        override val author: String? = null,
-        override val responsible: String? = null,
-        override val medicalLocationId: String? = null,
-        override val tags: Set<CodeStub> = emptySet(),
-        override val codes: Set<CodeStub> = emptySet(),
-        override val endOfLife: Long? = null,
-       override val deletionDate: Long? = null,
-        val size: Long? = null,
-        val hash: String? = null,
-        val openingContactId: String? = null,
+    override val id: String,
+    override val rev: String? = null,
+    override val created: Long? = null,
+    override val modified: Long? = null,
+    override val author: String? = null,
+    override val responsible: String? = null,
+    override val medicalLocationId: String? = null,
+    override val tags: Set<CodeStub> = emptySet(),
+    override val codes: Set<CodeStub> = emptySet(),
+    override val endOfLife: Long? = null,
+    override val deletionDate: Long? = null,
+    val size: Long? = null,
+    val hash: String? = null,
+    val openingContactId: String? = null,
+    val documentLocation: DocumentLocation? = null,
+    val documentType: DocumentType? = null,
+    val documentStatus: DocumentStatus? = null,
+    val externalUri: String? = null,
+    val name: String? = null,
+    val version: String? = null,
+    val storedICureDocumentId: String? = null, //The ICureDocument (Form, Contact, ...) that has been used to generate the document
+    val externalUuid: String? = null,
 
-        val objectStoreReference: String? = null,
-        val attachment: ByteArray? = null,
-        var isAttachmentDirty: Boolean = false,
-        val documentLocation: DocumentLocation? = null,
-        val documentType: DocumentType? = null,
-        val documentStatus: DocumentStatus? = null,
-        val externalUri: String? = null,
-        val mainUti: String? = null,
-        val name: String? = null,
-        val version: String? = null,
-        val otherUtis: Set<String> = emptySet(),
-        val storedICureDocumentId: String? = null, //The ICureDocument (Form, Contact, ...) that has been used to generate the document
-        val externalUuid: String? = null,
-        val attachmentId: String? = null,
+    val attachmentId: String? = null,
+    val objectStoreReference: String? = null,
+    val mainUti: String? = null,
+    val otherUtis: Set<String> = emptySet(),
+    val secondaryAttachments: Map<String, DataAttachment> = emptyMap(),
+    override val deletedAttachments: List<DeletedAttachment> = emptyList(),
 
-        override val secretForeignKeys: Set<String> = emptySet(),
-        override val cryptedForeignKeys: Map<String, Set<Delegation>> = emptyMap(),
-        override val delegations: Map<String, Set<Delegation>> = emptyMap(),
-        override val encryptionKeys: Map<String, Set<Delegation>> = emptyMap(),
-        override val encryptedSelf: String? = null,
+    override val secretForeignKeys: Set<String> = emptySet(),
+    override val cryptedForeignKeys: Map<String, Set<Delegation>> = emptyMap(),
+    override val delegations: Map<String, Set<Delegation>> = emptyMap(),
+    override val encryptionKeys: Map<String, Set<Delegation>> = emptyMap(),
+    override val encryptedSelf: String? = null,
 
-       override val revisionsInfo: List<RevisionInfo>? = emptyList(),
-       override val conflicts: List<String>? = emptyList(),
-       override val revHistory: Map<String, String>? = emptyMap()
+    val attachments: Map<String, Attachment>? = emptyMap(),
+    override val revisionsInfo: List<RevisionInfo>? = emptyList(),
+    override val conflicts: List<String>? = emptyList(),
+    override val revHistory: Map<String, String>? = emptyMap()
 
-) : StoredICureDocument, Encryptable {
+) : StoredICureDocument, Encryptable, HasDataAttachments<Document> {
     companion object : DynamicInitializer<Document>
 
-    fun merge(other: Document) = Document(args = this.solveConflictsWith(other))
-    fun solveConflictsWith(other: Document) = super<StoredICureDocument>.solveConflictsWith(other) + super<Encryptable>.solveConflictsWith(other) + mapOf(
-            "documentLocation" to (this.documentLocation ?: other.documentLocation),
-            "documentType" to (this.documentType ?: other.documentType),
-            "documentStatus" to (this.documentStatus ?: other.documentStatus),
-            "openingContactId" to (this.openingContactId ?: other.openingContactId),
-            "externalUri" to (this.externalUri ?: other.externalUri),
-            "mainUti" to (this.mainUti ?: other.mainUti),
-            "name" to (this.name ?: other.name),
-            "version" to (this.version ?: other.version),
-            "otherUtis" to (other.otherUtis + this.otherUtis),
-            "storedICureDocumentId" to (this.storedICureDocumentId ?: other.storedICureDocumentId),
-            "externalUuid" to (this.externalUuid ?: other.externalUuid),
-            "attachmentId" to (this.attachmentId ?: other.attachmentId),
-            "attachment" to (this.attachment?.let { if (it.size >= other.attachment?.size ?: 0) it else other.attachment }
-                    ?: other.attachment)
-    )
+    val mainAttachmentKey: String get() = id
 
-    fun decryptAttachment(enckeys: List<String?>?): ByteArray? {
-        return enckeys
-                ?.filterNotNull()
-                ?.filter { sfk -> sfk.keyFromHexString().isValidAesKey() }
-                ?.mapNotNull { sfk ->
-                    try {
-                        attachment?.let { CryptoUtils.decryptAES(it, sfk.keyFromHexString()) }
-                    } catch (ignored: GeneralSecurityException) {
-                        null
-                    } catch (ignored: KeyException) {
-                        null
-                    } catch (ignored: IllegalArgumentException) {
-                        null
-                    }
-                }
-                ?.firstOrNull()
-                ?: attachment
+    val mainAttachment: DataAttachment? by lazy {
+        if (attachmentId != null || objectStoreReference != null)
+            DataAttachment(
+                attachmentId,
+                objectStoreReference,
+                listOfNotNull(mainUti) + (mainUti?.let { otherUtis - it } ?: otherUtis)
+            )
+        else
+            null
     }
 
-    override fun withIdRev(id: String?, rev: String) = if (id != null) this.copy(id = id, rev = rev) else this.copy(rev = rev)
-    override fun withDeletionDate(deletionDate: Long?) = this.copy(deletionDate = deletionDate)
-    override fun withTimestamps(created: Long?, modified: Long?) =
-            when {
-                created != null && modified != null -> this.copy(created = created, modified = modified)
-                created != null -> this.copy(created = created)
-                modified != null -> this.copy(modified = modified)
-                else -> this
-            }
+    override val dataAttachments: Map<String, DataAttachment> by lazy {
+        mainAttachment?.let { secondaryAttachments + (mainAttachmentKey to it) } ?: secondaryAttachments
+    }
 
+    override fun withUpdatedDataAttachment(key: String, newValue: DataAttachment?): Document =
+        if (key == mainAttachmentKey) {
+            withUpdatedMainAttachment(newValue)
+        } else if (newValue != null) {
+            copy(secondaryAttachments = secondaryAttachments + (key to newValue))
+        } else {
+            copy(secondaryAttachments = secondaryAttachments - key)
+        }
+
+    override fun withDataAttachments(newDataAttachments: Map<String, DataAttachment>): Document = this
+        .copy(secondaryAttachments = newDataAttachments.filter { it.key != mainAttachmentKey })
+        .withUpdatedMainAttachment(newDataAttachments[mainAttachmentKey])
+
+    override fun withDeletedAttachments(newDeletedAttachments: List<DeletedAttachment>): Document =
+        copy(deletedAttachments = newDeletedAttachments)
+
+    fun merge(other: Document) = Document(args = this.solveConflictsWith(other))
+
+    fun solveConflictsWith(other: Document) = super<StoredICureDocument>.solveConflictsWith(other) + super<Encryptable>.solveConflictsWith(other) + mapOf(
+        "size" to (this.size ?: other.size),
+        "hash" to (this.hash ?: other.hash),
+        "openingContactId" to (this.openingContactId ?: other.openingContactId),
+        "documentLocation" to (this.documentLocation ?: other.documentLocation),
+        "documentType" to (this.documentType ?: other.documentType),
+        "documentStatus" to (this.documentStatus ?: other.documentStatus),
+        "externalUri" to (this.externalUri ?: other.externalUri),
+        "name" to (this.name ?: other.name),
+        "version" to (this.version ?: other.version),
+        "storedICureDocumentId" to (this.storedICureDocumentId ?: other.storedICureDocumentId),
+        "externalUuid" to (this.externalUuid ?: other.externalUuid),
+        "deletedAttachments" to this.solveDeletedAttachmentsConflicts(other),
+    ) + this.solveDataAttachmentsConflicts(other).let { allDataAttachments ->
+        allDataAttachments[this.mainAttachmentKey].let { mainAttachment ->
+            mapOf(
+                "attachmentId" to mainAttachment?.couchDbAttachmentId,
+                "objectStoreReference" to mainAttachment?.objectStoreAttachmentId,
+                "mainUti" to mainUtiOf(mainAttachment),
+                "otherUtis" to otherUtisOf(mainAttachment),
+                "secondaryAttachments" to (allDataAttachments - this.mainAttachmentKey)
+            )
+        }
+    }
+
+    override fun withIdRev(id: String?, rev: String) =
+        if (id != null) this.copy(id = id, rev = rev) else this.copy(rev = rev)
+
+    override fun withDeletionDate(deletionDate: Long?) =
+        this.copy(deletionDate = deletionDate)
+
+    override fun withTimestamps(created: Long?, modified: Long?) =
+        when {
+            created != null && modified != null -> this.copy(created = created, modified = modified)
+            created != null -> this.copy(created = created)
+            modified != null -> this.copy(modified = modified)
+            else -> this
+        }
+
+    fun withUpdatedMainAttachment(newMainAttachment: DataAttachment?) =
+        this.copy(
+            attachmentId = newMainAttachment?.couchDbAttachmentId,
+            objectStoreReference = newMainAttachment?.objectStoreAttachmentId,
+            mainUti = mainUtiOf(newMainAttachment),
+            otherUtis = otherUtisOf(newMainAttachment),
+        )
+
+    private fun mainUtiOf(mainAttachment: DataAttachment?) =
+        mainAttachment?.utis?.firstOrNull()
+
+    private fun otherUtisOf(mainAttachment: DataAttachment?) =
+        mainAttachment?.utis?.drop(1)?.toSet() ?: emptySet()
 }

--- a/workload/src/main/kotlin/org/taktik/icure/entities/base/HasDataAttachments.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/base/HasDataAttachments.kt
@@ -1,0 +1,48 @@
+package org.taktik.icure.entities.base
+
+
+import org.taktik.icure.entities.Document
+import org.taktik.icure.entities.embed.DataAttachment
+import org.taktik.icure.entities.embed.DeletedAttachment
+import org.taktik.icure.entities.utils.MergeUtil
+
+/**
+ * Interface for entities which store part of their data as attachments.
+ */
+interface HasDataAttachments<T : HasDataAttachments<T>> : StoredDocument {
+    /**
+     * All data attachments associated to this entity. The key in this map represents the key of the attachment.
+     * By convention, in entities where there is a main attachment (e.g. [Document]) the key of the main attachment
+     * should be equal to the entity id, in order to avoid accidental collisions.
+     */
+    val dataAttachments: Map<String, DataAttachment>
+
+    /**
+     * History of all deleted attachments.
+     */
+    val deletedAttachments: List<DeletedAttachment>
+
+    fun withUpdatedDataAttachment(key: String, newValue: DataAttachment?): T
+
+    fun withDataAttachments(newDataAttachments: Map<String, DataAttachment>): T
+
+    fun withDeletedAttachments(newDeletedAttachments: List<DeletedAttachment>): T
+
+    fun solveDeletedAttachmentsConflicts(other: HasDataAttachments<T>): List<DeletedAttachment> = MergeUtil.mergeListsDistinct(
+        this.deletedAttachments,
+        other.deletedAttachments,
+        comparator = { a, b -> a.key == b.key && a.objectStoreAttachmentId == b.objectStoreAttachmentId && a.couchDbAttachmentId == b.couchDbAttachmentId }
+    )
+
+    fun solveDataAttachmentsConflicts(other: HasDataAttachments<T>): Map<String, DataAttachment> =
+        (this.dataAttachments.keys + other.dataAttachments.keys).associateWith { k ->
+            val a = this.dataAttachments[k]
+            val b = other.dataAttachments[k]
+            if (a != null && b != null) {
+                if (b.objectStoreAttachmentId != null && b.objectStoreAttachmentId == a.couchDbAttachmentId) // b is a "migrated" version of a
+                    b
+                else
+                    a
+            } else a ?: b!!
+        }
+}

--- a/workload/src/main/kotlin/org/taktik/icure/entities/embed/DataAttachment.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/embed/DataAttachment.kt
@@ -1,0 +1,54 @@
+package org.taktik.icure.entities.embed
+
+
+import java.io.Serializable
+
+/**
+ * Represent an attachment holding some additional data for an entity.
+ * At least one of [couchDbAttachmentId] or [objectStoreAttachmentId] is always not null.
+ * @property couchDbAttachmentId if the attachment is stored as a couchdb attachment this holds the id of the attachment, else null.
+ * @property objectStoreAttachmentId if the attachment is stored with the object storage service this holds the id of the attachment, else null.
+ * @property utis [Uniform Type Identifiers](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-CHDHIJDE) for the data attachment.
+ * This is a list in order to allow specifying a priority, but each uti must be unique.
+ */
+data class DataAttachment(
+    val couchDbAttachmentId: String? = null,
+    val objectStoreAttachmentId: String? = null,
+    val utis: List<String> = emptyList()
+) : Serializable {
+    init {
+        require(couchDbAttachmentId != null || objectStoreAttachmentId != null) {
+            "Must specify the id of at least one storage place for the attachment"
+        }
+        require(utis.distinct().size == utis.size) {
+            val duplicates = utis.groupingBy { it }.eachCount().filter { it.value > 1 }.toList()
+            "There are duplicate utis: $duplicates"
+        }
+    }
+
+    companion object {
+        /**
+         * Default mime type for data attachments, if no specific uti is provided.
+         */
+        const val DEFAULT_MIME_TYPE = "application/xml"
+    }
+
+    private var cachedBytes: ByteArray? = null
+
+    val ids: Pair<String?, String?> get() = couchDbAttachmentId to objectStoreAttachmentId
+
+    /**
+     * @return if this and other attachment have the same ids (the attachment is the same and is stored in the same place)
+     */
+    infix fun hasSameIdsAs(other: DataAttachment) =
+        this.ids == other.ids
+
+    /**
+     * @return a copy of this data attachment where the ids are replaced with those of another data attachment
+     */
+    fun withIdsOf(other: DataAttachment) = copy(
+        couchDbAttachmentId = other.couchDbAttachmentId,
+        objectStoreAttachmentId = other.objectStoreAttachmentId
+    )
+
+}

--- a/workload/src/main/kotlin/org/taktik/icure/entities/embed/DeletedAttachment.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/entities/embed/DeletedAttachment.kt
@@ -1,0 +1,10 @@
+package org.taktik.icure.entities.embed
+
+import java.io.Serializable
+
+data class DeletedAttachment(
+    val couchDbAttachmentId: String? = null,
+    val objectStoreAttachmentId: String? = null,
+    val key: String? = null,
+    val deletionTime: Long? = null
+) : Serializable

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/DocumentDto.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/DocumentDto.kt
@@ -17,55 +17,58 @@
  */
 package org.taktik.icure.services.external.rest.v1.dto
 
-
 import org.taktik.icure.services.external.rest.v1.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v1.dto.base.EncryptableDto
 import org.taktik.icure.services.external.rest.v1.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v1.dto.base.StoredDocumentDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.DataAttachmentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DelegationDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.DeletedAttachmentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DocumentLocationDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DocumentStatusDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DocumentTypeDto
 
 data class DocumentDto(
-         override val id: String,
-         override val rev: String? = null,
-        override val created: Long? = null,
-        override val modified: Long? = null,
-        override val author: String? = null,
-        override val responsible: String? = null,
-        override val medicalLocationId: String? = null,
-        override val tags: Set<CodeStubDto> = emptySet(),
-        override val codes: Set<CodeStubDto> = emptySet(),
-        override val endOfLife: Long? = null,
-        override val deletionDate: Long? = null,
+    override val id: String,
+    override val rev: String? = null,
+    override val created: Long? = null,
+    override val modified: Long? = null,
+    override val author: String? = null,
+    override val responsible: String? = null,
+    override val medicalLocationId: String? = null,
+    override val tags: Set<CodeStubDto> = emptySet(),
+    override val codes: Set<CodeStubDto> = emptySet(),
+    override val endOfLife: Long? = null,
+    override val deletionDate: Long? = null,
 
-         val objectStoreReference: String? = null,
-         val documentLocation: DocumentLocationDto? = null,
-         val documentType: DocumentTypeDto? = null,
-         val documentStatus: DocumentStatusDto? = null,
-         val externalUri: String? = null,
-         val mainUti: String? = null,
-         val name: String? = null,
-         val version: String? = null,
-         val otherUtis: Set<String> = emptySet(),
-         val storedICureDocumentId: String? = null, //The ICureDocumentDto (FormDto, ContactDto, ...) that has been used to generate the document
-         val externalUuid: String? = null,
-         val size: Long? = null,
-         val hash: String? = null,
-         val openingContactId: String? = null,
+    val documentLocation: DocumentLocationDto? = null,
+    val documentType: DocumentTypeDto? = null,
+    val documentStatus: DocumentStatusDto? = null,
+    val externalUri: String? = null,
+    val name: String? = null,
+    val version: String? = null,
+    val storedICureDocumentId: String? = null, //The ICureDocumentDto (FormDto, ContactDto, ...) that has been used to generate the document
+    val externalUuid: String? = null,
+    val size: Long? = null,
+    val hash: String? = null,
+    val openingContactId: String? = null,
 
-         val attachmentId: String? = null,
+    val attachmentId: String? = null,
+    val objectStoreReference: String? = null,
+    val mainUti: String? = null,
+    val otherUtis: Set<String> = emptySet(),
+    val secondaryAttachments: Map<String, DataAttachmentDto> = emptyMap(),
+    val deletedAttachments: List<DeletedAttachmentDto> = emptyList(),
 
-        @Schema(type = "string", format = "byte") val encryptedAttachment: ByteArray? = null,
-        @Schema(type = "string", format = "byte") val decryptedAttachment: ByteArray? = null,
+    val encryptedAttachment: ByteArray? = null,
+    val decryptedAttachment: ByteArray? = null,
 
-        override val secretForeignKeys: Set<String> = emptySet(),
-        override val cryptedForeignKeys: Map<String, Set<DelegationDto>> = emptyMap(),
-        override val delegations: Map<String, Set<DelegationDto>> = emptyMap(),
-        override val encryptionKeys: Map<String, Set<DelegationDto>> = emptyMap(),
+    override val secretForeignKeys: Set<String> = emptySet(),
+    override val cryptedForeignKeys: Map<String, Set<DelegationDto>> = emptyMap(),
+    override val delegations: Map<String, Set<DelegationDto>> = emptyMap(),
+    override val encryptionKeys: Map<String, Set<DelegationDto>> = emptyMap(),
 
-        override val encryptedSelf: String? = null
+    override val encryptedSelf: String? = null
 ) : StoredDocumentDto, ICureDocumentDto<String>, EncryptableDto {
     override fun withIdRev(id: String?, rev: String) = if (id != null) this.copy(id = id, rev = rev) else this.copy(rev = rev)
     override fun withDeletionDate(deletionDate: Long?) = this.copy(deletionDate = deletionDate)

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DataAttachmentDto.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DataAttachmentDto.kt
@@ -1,0 +1,9 @@
+package org.taktik.icure.services.external.rest.v1.dto.embed
+
+import java.io.Serializable
+
+data class DataAttachmentDto(
+    val couchDbAttachmentId: String? = null,
+    val objectStoreAttachmentId: String? = null,
+    val utis: List<String> = emptyList()
+) : Serializable

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DeletedAttachmentDto.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DeletedAttachmentDto.kt
@@ -1,0 +1,13 @@
+package org.taktik.icure.services.external.rest.v1.dto.embed
+
+import java.io.Serializable
+
+data class DeletedAttachmentDto(
+    val couchDbAttachmentId: String? = null,
+
+    val objectStoreAttachmentId: String? = null,
+
+    val key: String? = null,
+
+    val deletionTime: Long? = null
+) : Serializable

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ApplicationSettingsMapper.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ApplicationSettingsMapper.kt
@@ -25,7 +25,7 @@ import org.mapstruct.Mappings
 import org.taktik.icure.entities.ApplicationSettings
 import org.taktik.icure.services.external.rest.v1.dto.ApplicationSettingsDto
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeStubMapper
-
+//asdadasfghfhf
 @Mapper(componentModel = "spring", uses = [CodeStubMapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 interface ApplicationSettingsMapper {
     @Mappings(

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
@@ -25,26 +25,34 @@ import org.mapstruct.Mappings
 import org.taktik.icure.entities.Document
 import org.taktik.icure.services.external.rest.v1.dto.DocumentDto
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeStubMapper
+import org.taktik.icure.services.external.rest.v1.mapper.embed.DataAttachmentMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.DelegationMapper
-import org.taktik.icure.services.external.rest.v1.mapper.embed.DocumentLocationMapper
-import org.taktik.icure.services.external.rest.v1.mapper.embed.DocumentStatusMapper
-import org.taktik.icure.services.external.rest.v1.mapper.embed.DocumentTypeMapper
+import org.taktik.icure.services.external.rest.v1.mapper.embed.DeletedAttachmentMapper
 
-@Mapper(componentModel = "spring", uses = [DocumentTypeMapper::class, DocumentLocationMapper::class, CodeStubMapper::class, DelegationMapper::class, DocumentStatusMapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+// Useless comment 5
+
+@Mapper(
+    componentModel = "spring",
+    uses = [
+        CodeStubMapper::class,
+        DelegationMapper::class,
+        DataAttachmentMapper::class,
+        DeletedAttachmentMapper::class
+    ],
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
 interface DocumentMapper {
     @Mappings(
-            Mapping(target = "attachment", ignore = true),
-            Mapping(target = "isAttachmentDirty", ignore = true),
-
-            Mapping(target = "attachments", ignore = true),
-            Mapping(target = "revHistory", ignore = true),
-            Mapping(target = "conflicts", ignore = true),
-            Mapping(target = "revisionsInfo", ignore = true)
-            )
-	fun map(documentDto: DocumentDto):Document
-    @Mappings(
-            Mapping(target = "encryptedAttachment", ignore = true),
-            Mapping(target = "decryptedAttachment", ignore = true)
+        Mapping(target = "attachments", ignore = true),
+        Mapping(target = "revHistory", ignore = true),
+        Mapping(target = "conflicts", ignore = true),
+        Mapping(target = "revisionsInfo", ignore = true)
     )
-	fun map(document: Document):DocumentDto
+    fun map(documentDto: DocumentDto): Document
+
+    @Mappings(
+        Mapping(target = "encryptedAttachment", ignore = true),
+        Mapping(target = "decryptedAttachment", ignore = true)
+    )
+    fun map(document: Document): DocumentDto
 }

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/DataAttachmentMapper.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/DataAttachmentMapper.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.services.external.rest.v1.mapper.embed
+
+import org.mapstruct.InjectionStrategy
+import org.mapstruct.Mapper
+import org.taktik.icure.entities.embed.DataAttachment
+import org.taktik.icure.services.external.rest.v1.dto.embed.DataAttachmentDto
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+interface DataAttachmentMapper {
+    fun map(dataAttachmentDto: DataAttachmentDto): DataAttachment
+    fun map(dataAttachment: DataAttachment): DataAttachmentDto
+}

--- a/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/DeletedAttachmentMapper.kt
+++ b/workload/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/DeletedAttachmentMapper.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.services.external.rest.v1.mapper.embed
+
+import org.mapstruct.InjectionStrategy
+import org.mapstruct.Mapper
+import org.taktik.icure.entities.embed.DeletedAttachment
+import org.taktik.icure.services.external.rest.v1.dto.embed.DeletedAttachmentDto
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+interface DeletedAttachmentMapper {
+    fun map(deletedAttachmentDto: DeletedAttachmentDto): DeletedAttachment
+    fun map(deletedAttachment: DeletedAttachment): DeletedAttachmentDto
+}


### PR DESCRIPTION
Updated map processing to take into account non nullable keys and values.

The previous implementation used ?.let { } to convert keys and values to one type of map to the other, however Kotlin 1.7 cannot compile because of this as it interprets the new type of the key/value as nullable.

In this implementation, if a key/value is non-nullable, the .let {} call (without safe assertion) is used